### PR TITLE
[REVIEW BEFORE APACHE PR] Approach 3: handle raw values in regex evaluator (no dictionary at scan time)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictIdBasedRegexpLikePredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictIdBasedRegexpLikePredicateEvaluator.java
@@ -18,14 +18,55 @@
  */
 package org.apache.pinot.core.operator.filter.predicate;
 
+import java.util.regex.Matcher;
 import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 
 
 /// Base class for dictionary-based REGEXP_LIKE predicate evaluators that use dictionary IDs for matching.
 public abstract class BaseDictIdBasedRegexpLikePredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
 
+  // Reused matcher for evaluating the regex against raw string values from the forward index. Used only on the
+  // scan path when the forward index is RAW (no dict-encoded forward stream is available) and no inverted/sorted
+  // index can serve the predicate, so the IFST/FST-precomputed matching-dict-id set cannot be leveraged. Not
+  // thread-safe; the evaluator is expected to be used by a single thread (one query, one segment slice).
+  private final Matcher _rawValueMatcher;
+
   protected BaseDictIdBasedRegexpLikePredicateEvaluator(Predicate predicate, Dictionary dictionary) {
     super(predicate, dictionary);
+    _rawValueMatcher = ((RegexpLikePredicate) predicate).getPattern().matcher("");
+  }
+
+  /// Evaluate the predicate against a raw string value (forward-index value), bypassing the dictionary. This is the
+  /// fallback path used by the scan filter operator when the forward index is RAW but a dictionary still exists for
+  /// secondary indexes (e.g. IFST); the matcher in {@link
+  /// org.apache.pinot.core.operator.dociditerators.SVScanDocIdIterator} reads raw strings and calls this method
+  /// instead of {@code applySV(int dictId)}.
+  @Override
+  public boolean applySV(String value) {
+    if (_alwaysFalse) {
+      return false;
+    }
+    if (_alwaysTrue) {
+      return true;
+    }
+    return _rawValueMatcher.reset(value).find();
+  }
+
+  @Override
+  public boolean applyMV(String[] values, int length) {
+    if (_alwaysFalse) {
+      return false;
+    }
+    if (_alwaysTrue) {
+      return true;
+    }
+    for (int i = 0; i < length; i++) {
+      if (_rawValueMatcher.reset(values[i]).find()) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictionaryBasedPredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictionaryBasedPredicateEvaluator.java
@@ -129,12 +129,12 @@ public abstract class BaseDictionaryBasedPredicateEvaluator extends BasePredicat
   }
 
   @Override
-  public final boolean applySV(String value) {
+  public boolean applySV(String value) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public final boolean applyMV(String[] values, int length) {
+  public boolean applyMV(String[] values, int length) {
     throw new UnsupportedOperationException();
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/BaseDictIdBasedRegexpLikePredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/BaseDictIdBasedRegexpLikePredicateEvaluatorTest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate;
+
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that dict-id based REGEXP_LIKE evaluators (IFST/FST/DictId) correctly evaluate raw string values
+ * via the regex matcher when the scan iterator calls {@code applySV(String)}. This path is taken when the
+ * forward index is RAW and a separate dictionary exists, but no inverted/sorted index is available — i.e.
+ * the planner falls through to {@code ScanBasedFilterOperator} carrying a dict-based evaluator.
+ *
+ * Prior to this fix, the inherited {@code applySV(String)} from {@code BaseDictionaryBasedPredicateEvaluator}
+ * threw {@code UnsupportedOperationException} and the query crashed.
+ */
+public class BaseDictIdBasedRegexpLikePredicateEvaluatorTest {
+
+  @Test
+  public void applySVStringMatchesCaseSensitiveRegex() {
+    TestEvaluator evaluator = newEvaluator("^foo");
+
+    assertTrue(evaluator.applySV("foobar"));
+    assertTrue(evaluator.applySV("foo"));
+    assertFalse(evaluator.applySV("FOO"));        // case-sensitive
+    assertFalse(evaluator.applySV("barfoo"));     // not at start
+    assertFalse(evaluator.applySV(""));
+  }
+
+  @Test
+  public void applySVStringMatchesCaseInsensitiveRegex() {
+    TestEvaluator evaluator = newEvaluator("^foo", "i");
+
+    assertTrue(evaluator.applySV("foobar"));
+    assertTrue(evaluator.applySV("FOObar"));
+    assertTrue(evaluator.applySV("FoOzilla"));
+    assertFalse(evaluator.applySV("barfoo"));
+  }
+
+  @Test
+  public void applyMVStringReturnsTrueIfAnyMatches() {
+    TestEvaluator evaluator = newEvaluator("^foo");
+
+    assertTrue(evaluator.applyMV(new String[]{"bar", "baz", "foobar"}, 3));
+    assertFalse(evaluator.applyMV(new String[]{"bar", "baz", "qux"}, 3));
+    // Length param is respected — only the first 2 are inspected.
+    assertFalse(evaluator.applyMV(new String[]{"bar", "baz", "foobar"}, 2));
+  }
+
+  @Test
+  public void alwaysFalseShortCircuitsRawValuePath() {
+    TestEvaluator evaluator = newEvaluator("^foo");
+    evaluator.setAlwaysFalse();
+
+    assertFalse(evaluator.applySV("foobar"));
+    assertFalse(evaluator.applyMV(new String[]{"foobar"}, 1));
+  }
+
+  @Test
+  public void alwaysTrueShortCircuitsRawValuePath() {
+    TestEvaluator evaluator = newEvaluator("^foo");
+    evaluator.setAlwaysTrue();
+
+    assertTrue(evaluator.applySV("anything"));
+    assertTrue(evaluator.applyMV(new String[]{"anything"}, 1));
+  }
+
+  private static TestEvaluator newEvaluator(String regex) {
+    return newEvaluator(regex, null);
+  }
+
+  private static TestEvaluator newEvaluator(String regex, String matchParameter) {
+    RegexpLikePredicate predicate = matchParameter == null
+        ? new RegexpLikePredicate(ExpressionContext.forIdentifier("col"), regex)
+        : new RegexpLikePredicate(ExpressionContext.forIdentifier("col"), regex, matchParameter);
+    Dictionary dictionary = Mockito.mock(Dictionary.class);
+    return new TestEvaluator(predicate, dictionary);
+  }
+
+  /// Minimal concrete subclass for the test. We only exercise the raw-value path, so the dict-id path can be a
+  /// trivial stub.
+  private static class TestEvaluator extends BaseDictIdBasedRegexpLikePredicateEvaluator {
+
+    TestEvaluator(RegexpLikePredicate predicate, Dictionary dictionary) {
+      super(predicate, dictionary);
+    }
+
+    void setAlwaysTrue() {
+      _alwaysTrue = true;
+    }
+
+    void setAlwaysFalse() {
+      _alwaysFalse = true;
+    }
+
+    @Override
+    public boolean applySV(int dictId) {
+      // Unused on the raw-value path; tests only call applySV(String) / applyMV(String[]).
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Internal review only — not yet targeted at apache/master.

Replaces the matcher-level fix in #18579 (Approach 1) with an evaluator-level fix per @Jackie-Jiang's feedback: <https://github.com/apache/pinot/pull/18579#issuecomment-4546819452>

> *"This is not the correct fix. It is way too expensive to lookup every single value within forward index. The correct fix should be within predicate evaluator to handle raw values even when dictionary exist"*

## What changes

| | Approach 1 (current PR #18579) | Approach 3 (this PR) |
|---|---|---|
| Where the fix lives | `SVScanDocIdIterator` (scan iterator) | `BaseDictIdBasedRegexpLikePredicateEvaluator` (the evaluator base) |
| Per-row work | `dict.indexOf(rawValue)` then `applySV(int)` | `matcher.reset(rawValue).find()` — direct regex |
| Dictionary touched per row | yes — 19M times | **no — never** |
| Files modified | 1 | 2 |
| New matcher classes | 7 | 0 |
| Scan iterator awareness of `Dictionary` | yes | no — unchanged |
| Evaluator's `applySV(String)` contract | still throws | now works on regex evaluators |

## Files

- `BaseDictionaryBasedPredicateEvaluator.java` — drop `final` from `applySV(String)` / `applyMV(String[])` (defaults still throw, just allow override)
- `BaseDictIdBasedRegexpLikePredicateEvaluator.java` — store a `Matcher` from the predicate's `Pattern`, override `applySV(String)` and `applyMV(String[], int)` to run the regex directly
- `BaseDictIdBasedRegexpLikePredicateEvaluatorTest.java` — new unit test covering case-sensitive, case-insensitive, MV, and `_alwaysTrue` / `_alwaysFalse` short-circuit paths

Automatically covers all three concrete dict-id-based regex evaluators (they all extend the base):
- `DictIdBasedRegexpLikePredicateEvaluator` (small dict, eager)
- `IFSTBasedRegexpPredicateEvaluator` (case-insensitive FST)
- `FSTBasedRegexpPredicateEvaluator` (case-sensitive FST)

## Per-row cost

| Indexes on column | Operator chosen | Per-row work |
|---|---|---|
| inverted (with/without IFST) | `InvertedIndexFilterOperator` | none — bitmap union |
| IFST, no inverted, dict-encoded fwd | `ScanBasedFilterOperator` → `DictIdMatcher` | dict-id read (~5 ns) + IntSet membership |
| **IFST, no inverted, RAW fwd** (the bug) | `ScanBasedFilterOperator` → `StringMatcher` | **regex eval directly on raw value** (~100–200 ns for simple regex) |

For complex regex with backtracking, the per-row regex cost can be µs; in that case the precomputed-values approach (Approach 2) would be faster but at the cost of more code and dictionary touches at setup. Approach 3 trades raw simplicity for some per-row cost on complex regex.

## Trade-offs vs Approach 2 (precomputed `Set<String>`)

| | Approach 2 | Approach 3 (this) |
|---|---|---|
| Per-row | `HashSet.contains(value)` (~30 ns) | `matcher.find(value)` (~100–500 ns) |
| Setup | one-time dict iteration to build matching-values set | none |
| Dictionary touched at setup | yes — `getStringValue` for each matching dict ID | no |
| Code size | ~240 lines in base class | ~44 lines in regex base |
| Reuses IFST's matching-dict-ids work | yes | no (IFST work is computed but unused on this path) |

Approach 3 is what was explicitly asked for ("dictionary not utilized") and is the minimal change. If profiling shows the per-row regex is a bottleneck on a real workload, Approach 2 is the next step.

## Test plan

- [ ] `BaseDictIdBasedRegexpLikePredicateEvaluatorTest` covers the new methods
- [ ] Existing `RegexpLikePredicateEvaluatorFactory` tests should pass unchanged
- [ ] Manual: re-run `regexp_like(col, 'pattern', 'i')` and `LIKE 'pattern'` queries against the iceberg/external-table that triggered the original crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)