### PR TITLE
Fall back to raw-value REGEXP_LIKE evaluator when no dict-consuming index is available

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -309,8 +309,13 @@ public class FilterPlanNode implements PlanNode {
               // Check if case-insensitive flag is present
               RegexpLikePredicate regexpLikePredicate = (RegexpLikePredicate) predicate;
               boolean caseInsensitive = regexpLikePredicate.isCaseInsensitive();
+              // IFST/FST evaluators are dict-id based and can only be consumed by sorted/inverted-index filter
+              // operators. If neither is available for this segment, the planner will fall through to
+              // ScanBasedFilterOperator, which reads raw values from the forward index and cannot service a
+              // dict-id evaluator (applySV(String) throws on BaseDictionaryBasedPredicateEvaluator). In that
+              // case, route through the raw-value evaluator instead.
               if (caseInsensitive) {
-                if (dataSource.getIFSTIndex() != null) {
+                if (dataSource.getIFSTIndex() != null && canConsumeDictIdEvaluator(dataSource, _queryContext)) {
                   predicateEvaluator =
                       IFSTBasedRegexpPredicateEvaluatorFactory.newIFSTBasedEvaluator(regexpLikePredicate,
                           dataSource.getIFSTIndex(), dataSource.getDictionary());
@@ -319,7 +324,7 @@ public class FilterPlanNode implements PlanNode {
                       PredicateEvaluatorProvider.getPredicateEvaluator(predicate, dataSource, _queryContext);
                 }
               } else {
-                if (dataSource.getFSTIndex() != null) {
+                if (dataSource.getFSTIndex() != null && canConsumeDictIdEvaluator(dataSource, _queryContext)) {
                   predicateEvaluator = FSTBasedRegexpPredicateEvaluatorFactory.newFSTBasedEvaluator(regexpLikePredicate,
                       dataSource.getFSTIndex(), dataSource.getDictionary());
                 } else {
@@ -431,6 +436,30 @@ public class FilterPlanNode implements PlanNode {
     DataSource dataSource = _indexSegment.getDataSource(column, _queryContext.getSchema());
     return constructVectorSimilarityOperator(dataSource, (VectorSimilarityPredicate) predicate, column,
         numDocs, true);
+  }
+
+  /// Returns true if a dictionary-id based REGEXP_LIKE evaluator (e.g. IFST/FST/DictId) can be consumed at run time
+  /// either by:
+  ///   1. A sorted-index filter operator (`SortedIndexBasedFilterOperator`).
+  ///   2. An inverted-index filter operator (`InvertedIndexFilterOperator`).
+  ///   3. The scan filter operator when the forward index is dictionary-encoded (`DictIdMatcher` in
+  ///      `SVScanDocIdIterator` reads dict ids from the forward index and calls `applySV(int dictId)`).
+  ///
+  /// When false, the scan path will pick a typed raw matcher (e.g. `StringMatcher`) and call
+  /// `applySV(<rawType>)`, which a dict-id evaluator cannot service. In that case the IFST/FST evaluator should be
+  /// skipped in favor of the raw-value evaluator
+  /// (`RegexpLikePredicateEvaluatorFactory#newRawValueBasedEvaluator`).
+  private static boolean canConsumeDictIdEvaluator(DataSource dataSource, QueryContext queryContext) {
+    if (dataSource.getDataSourceMetadata().isSorted()
+        && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.SORTED)) {
+      return true;
+    }
+    if (dataSource.getInvertedIndex() != null
+        && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.INVERTED)) {
+      return true;
+    }
+    ForwardIndexReader forwardIndex = dataSource.getForwardIndex();
+    return forwardIndex != null && forwardIndex.isDictionaryEncoded();
   }
 
   /**


### PR DESCRIPTION
Internal fork PR — review only, not against apache/master.

Approach 4 for the REGEXP_LIKE crash on RAW forward + dictionary + FST/IFST + no inverted/sorted, addressing @Jackie-Jiang's feedback on apache#18579: <https://github.com/apache/pinot/pull/18579#issuecomment-4546819452>

## Diff

Single commit, single file: `pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java`, **+31 / -2**.

Branch is based on `deepthi/svscan-dict-lookup-matcher` (the merged Approach 1 head) so the diff shows only this commit. Apache/master would receive the Approach 4 commit cleanly on top of the already-merged #18579.

## What it does

Guards the IFST/FST evaluator construction so it only happens when a dict-consuming filter operator will actually be picked:

```java
if (caseInsensitive) {
  if (dataSource.getIFSTIndex() != null
      && canConsumeDictIdEvaluator(dataSource, _queryContext)) {
    predicateEvaluator = IFSTBasedRegexpPredicateEvaluatorFactory.newIFSTBasedEvaluator(...);
  } else {
    predicateEvaluator = PredicateEvaluatorProvider.getPredicateEvaluator(predicate, dataSource, _queryContext);
  }
}
// mirror for case-sensitive FST branch

private static boolean canConsumeDictIdEvaluator(DataSource dataSource, QueryContext queryContext) {
  // sorted-index filter operator
  if (dataSource.getDataSourceMetadata().isSorted()
      && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.SORTED)) return true;
  // inverted-index filter operator
  if (dataSource.getInvertedIndex() != null
      && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.INVERTED)) return true;
  // scan + DictIdMatcher (when forward index is dict-encoded)
  ForwardIndexReader<?> fwd = dataSource.getForwardIndex();
  return fwd != null && fwd.isDictionaryEncoded();
}
```

## Behavior matrix

| Forward index | FST/IFST | Sorted | Inverted | Evaluator | Filter operator | Status |
|---|---|---|---|---|---|---|
| DICT | yes | no | no | FST/IFST eval | scan + `DictIdMatcher` | ✅ |
| DICT | yes | no | yes | FST/IFST eval | InvertedIndex | ✅ |
| DICT | yes | yes | no | FST/IFST eval | SortedIndex | ✅ |
| **RAW** | yes | no | no | **raw eval (fallback)** | scan + `StringMatcher` | **✅ fixed** |
| RAW | yes | no | yes | FST/IFST eval | InvertedIndex | ✅ |

## Compared to previous approaches

| | A1 (merged in apache#18579) | A2 (precomputed values) | A3 (regex in evaluator) | **A4 (this)** |
|---|---|---|---|---|
| Files | `SVScanDocIdIterator` | `BaseDictionaryBasedPredicateEvaluator` | `BaseDict[Id]Based*` | `FilterPlanNode` |
| Lines | +107 | +240 | +44 | **+31** |
| Per-row work | per-row `dict.indexOf` | HashSet lookup | per-row regex | per-row regex (existing raw eval) |
| Wasted FST/IFST construction when scan path is picked | yes | yes | yes | **no — never built** |
| Touches scan iterator | yes | no | no | **no** |
| Touches base evaluator classes | no | yes | yes | **no** |

## Known limitation (separate follow-up)

`ScanBasedRegexpLikePredicateEvaluator` (used when dict ≥10K entries) extends `BaseDictionaryBasedPredicateEvaluator` directly, not `BaseDictIdBasedRegexpLikePredicateEvaluator`. `FilterOperatorUtils#getLeafFilterOperator` only routes the latter to InvertedIndex/SortedIndex, so **RAW forward + dict ≥10K + inverted + no FST/IFST** still crashes (independent of this PR). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)